### PR TITLE
test patch for unresponsiveness during setting tabs enumeration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,9 +127,10 @@ export default class SettingsSearch extends Plugin {
     loaded = false;
     tabIndex = 0;
     pluginTabIndex = 0;
+    seen: string[] = [];
     buildResources() {
         const tab = this.app.setting.settingTabs[this.tabIndex];
-        if (tab) {
+        if (tab && tab.id !== undefined && (!this.seen.includes(tab.id))) {
             this.getTabResources(tab);
             this.tabIndex++;
             setTimeout(() => this.buildResources());
@@ -284,7 +285,6 @@ export default class SettingsSearch extends Plugin {
     }
     async getTabResources(tab: SettingTab) {
         await tab.display();
-
         const settings = tab.containerEl.querySelectorAll<HTMLDivElement>(
             ".setting-item:not(.setting-item-header)"
         );
@@ -309,6 +309,7 @@ export default class SettingsSearch extends Plugin {
             this.addResourceToCache(resource);
         }
         if (this.app.setting.activeTab?.id == tab.id) return;
+        this.seen.push(tab.id);
         tab.containerEl.detach();
         tab.hide();
     }
@@ -332,7 +333,9 @@ export default class SettingsSearch extends Plugin {
             around(this.app.setting, {
                 addSettingTab: function (next) {
                     return function (tab: SettingTab) {
-                        self.getTabResources(tab);
+                        if (tab && tab.id !== undefined && (!this.seen.includes(tab.id))) {
+                            self.getTabResources(tab);
+                        }
                         return next.call(this, tab);
                     };
                 }


### PR DESCRIPTION
## Pull Request Description

see also #33

I also had this issue today where Obsidian (1.4.12) would become very sluggish and unresponsive after loading, using 200% CPU etc.

After some debugging, I traced it to an infinite loop in the `getTabResources()` function, apparently caused by having https://github.com/Ebonsignori/obsidian-at-symbol-linking loaded. I don't know the exact reason, but I guess some label is undefined causing the func to endlessly recurse.

## Changes Proposed

I made a simple array and push the `tab.id`'s to it, and added a guard function around the monkeypatch to prevent infinitely reiterating over the same plugin.

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes

This was only minimally tested, I would appreciate comments and any suggestions if there is a better way to fix this.